### PR TITLE
Update wrangler v4 + --remote for R2 uploads

### DIFF
--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -84,7 +84,7 @@ jobs:
           fi
           for f in "${files[@]}"; do
             echo "Uploading $(basename $f)..."
-            if ! wrangler r2 object put "inthegame-data/$(basename $f)" --file "$f"; then
+            if ! wrangler r2 object put "inthegame-data/$(basename $f)" --file "$f" --remote; then
               echo "::error::Failed to upload $(basename $f) to R2"
               exit 1
             fi


### PR DESCRIPTION
## Summary
- Upgrade wrangler from v3 to v4 (v3 returns 403 with Account API Tokens)
- Add `--remote` flag to `r2 object put` (v4 defaults to local dev mode)

## Test plan
- [x] Workflow ran successfully on `dev` — parquets uploaded to R2 and accessible via public URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)