### PR TITLE
Add player pages data to blog pipeline

### DIFF
--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -57,6 +57,25 @@ jobs:
             exit 1
           fi
 
+          # Player details (latest year for bio data)
+          if gh release download player_details-data -p "player_details_${YEAR}.parquet" -D source 2>/dev/null; then
+            echo "Downloaded player_details for ${YEAR}"
+          elif gh release download player_details-data -p "player_details_$((YEAR-1)).parquet" -D source 2>/dev/null; then
+            echo "::warning::Fell back to player_details_$((YEAR-1)).parquet"
+          else
+            echo "::error::Failed to download player_details for ${YEAR} or $((YEAR-1))"
+            exit 1
+          fi
+
+          # Per-game ratings (current + prior season for game logs)
+          for yr in ${YEAR} $((YEAR-1)); do
+            if gh release download player_game_ratings-data -p "player_game_ratings_${yr}.parquet" -D source 2>/dev/null; then
+              echo "Downloaded player_game_ratings for ${yr}"
+            else
+              echo "::warning::player_game_ratings_${yr}.parquet not available, skipping"
+            fi
+          done
+
       - name: Aggregate
         run: Rscript scripts/build_blog_data.R
 

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -22,7 +22,7 @@ ratings <- season |>
     torp_hitout = season_hitout / games,
     gms = games
   ) |>
-  select(player_name, team, position, torp, torp_recv, torp_disp,
+  select(player_id, player_name, team, position, torp, torp_recv, torp_disp,
          torp_spoil, torp_hitout, gms, season) |>
   arrange(desc(torp))
 
@@ -32,7 +32,7 @@ latest_teams <- teams |>
   filter(season == max(season)) |>
   filter(round == max(as.numeric(round)))
 
-# Match predictions - rename columns, round values, and format for blog
+# Match predictions - one row per match (home perspective)
 pred_file <- list.files("source", pattern = "^predictions_", full.names = TRUE)
 if (length(pred_file) == 0) stop("No predictions file found in source/")
 if (length(pred_file) > 1) {
@@ -43,25 +43,72 @@ if (length(pred_file) > 1) {
 }
 preds <- read_parquet(pred_file) |>
   ungroup() |>
+  filter(team_type == "home") |>
   transmute(
-    round = week,
+    round = round.roundNumber.x,
     home_team = as.character(home_team),
     away_team = as.character(away_team),
-    home_rating = round(home_rating, 1),
-    away_rating = round(away_rating, 1),
-    pred_margin = round(pred_margin, 1),
+    home_rating = round(torp.x, 1),
+    away_rating = round(torp.y, 1),
+    pred_margin = round(pred_score_diff, 1),
     home_win_prob = round(pred_win, 3),
-    pred_total = round(pred_xtotal, 0),
-    actual_margin = margin
+    pred_total = round(pred_tot_xscore, 0),
+    actual_margin = score_diff
   ) |>
   arrange(round, desc(abs(pred_margin)))
 
+# Player details - bio data for player profile pages
+details_file <- list.files("source", pattern = "^player_details_", full.names = TRUE)
+if (length(details_file) == 0) stop("No player_details file found in source/")
+details_file <- max(details_file)
+details <- read_parquet(details_file) |>
+  transmute(
+    player_id = providerId,
+    player_name,
+    team,
+    position,
+    jumper_number = jumperNumber,
+    height_cm = heightInCm,
+    weight_kg = weightInKg,
+    date_of_birth = dateOfBirth,
+    draft_year = draftYear,
+    debut_year = debutYear,
+    recruited_from = recruitedFrom,
+    season
+  )
+
+# Game logs - per-game TORP ratings for latest 2 seasons
+game_files <- list.files("source", pattern = "^player_game_ratings_", full.names = TRUE)
+if (length(game_files) == 0) stop("No player_game_ratings files found in source/")
+game_logs <- lapply(game_files, read_parquet) |>
+  bind_rows() |>
+  transmute(
+    player_id,
+    player_name,
+    season,
+    round,
+    team,
+    opp,
+    torp = total_points,
+    torp_recv = recv_points,
+    torp_disp = disp_points,
+    torp_spoil = spoil_points,
+    torp_hitout = hitout_points,
+    match_id
+  ) |>
+  arrange(player_id, season, round)
+
 stopifnot(nrow(ratings) > 100, nrow(latest_teams) >= 18, nrow(preds) > 0)
+stopifnot(nrow(details) > 0, nrow(game_logs) > 0)
 
 dir.create("blog", showWarnings = FALSE)
 write_parquet(ratings, "blog/torp_ratings.parquet")
 write_parquet(latest_teams, "blog/torp_team_ratings.parquet")
 write_parquet(preds, "blog/torp_predictions.parquet")
+write_parquet(details, "blog/torp_player_details.parquet")
+write_parquet(game_logs, "blog/torp_game_logs.parquet")
 cat("torp_ratings:", nrow(ratings), "players\n")
 cat("torp_team_ratings:", nrow(latest_teams), "teams\n")
 cat("torp_predictions:", nrow(preds), "matches\n")
+cat("torp_player_details:", nrow(details), "players\n")
+cat("torp_game_logs:", nrow(game_logs), "game records\n")


### PR DESCRIPTION
## Summary
- Adds `player_id` to `torp_ratings.parquet` to enable player page linking
- Generates 2 new parquets: `torp_player_details.parquet` (bio data) and `torp_game_logs.parquet` (per-game TORP, 2 seasons)
- Fixes predictions column mapping to match current raw predictions format
- Updates workflow to download `player_details` and `player_game_ratings` source data

## Test plan
- [x] Local `Rscript scripts/build_blog_data.R` passes (667 players, 780 details, 19766 game records, 216 predictions, 18 teams)
- [ ] Run "Build blog data" workflow after merge
- [ ] Verify new parquets appear on R2

🤖 Generated with [Claude Code](https://claude.com/claude-code)