### PR TITLE
ci: accept blog-trigger dispatch from torp

### DIFF
--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -1,13 +1,9 @@
 name: Build blog data
 
 on:
+  repository_dispatch:
+    types: [blog-trigger]
   workflow_dispatch:
-  # To trigger after the daily pipeline, uncomment and add
-  # `if: github.event.workflow_run.conclusion == 'success'` to the job
-  # (completed fires on both success and failure):
-  # workflow_run:
-  #   workflows: ["Daily Data Release"]
-  #   types: [completed]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Adds `repository_dispatch: blog-trigger` to build-blog-data.yml
- Enables automatic R2 uploads after torp completes ratings/predictions

## Test plan
- [ ] Trigger via repository dispatch and verify R2 uploads

🤖 Generated with [Claude Code](https://claude.com/claude-code)