### PR TITLE
Fix simulations pipeline and update GH Action versions

### DIFF
--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -34,6 +34,21 @@ jobs:
             any::data.table
             any::cli
             any::devtools
+            any::ggplot2
+            any::httr
+            any::lubridate
+            any::mgcv
+            any::curl
+            any::digest
+            any::gh
+            any::jsonlite
+            any::purrr
+            any::rlang
+            any::stringi
+            any::stringr
+            any::tibble
+            any::tidyselect
+            any::withr
 
       - name: Download source parquets
         env:

--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -178,6 +178,26 @@ jobs:
             echo "::warning::player_skills_${YEAR}.parquet not available — skills data won't update"
           fi
 
+      - name: Validate outputs
+        run: |
+          echo "Files produced:"
+          ls -la blog/*.parquet 2>/dev/null || true
+
+          # Required — fail the build if missing
+          for f in ratings.parquet team-ratings.parquet predictions.parquet player-details.parquet game-logs.parquet; do
+            if [ ! -f "blog/$f" ]; then
+              echo "::error::Required output blog/$f was not produced"
+              exit 1
+            fi
+          done
+
+          # Optional — warn but don't fail
+          for f in simulations.parquet shots.parquet game-stats.parquet player-skills.parquet; do
+            if [ ! -f "blog/$f" ]; then
+              echo "::warning::Optional output blog/$f was not produced"
+            fi
+          done
+
       - uses: actions/setup-node@v6
         with:
           node-version: '20'

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -81,7 +81,7 @@ sequenceDiagram
 
 ## Components
 
-### GitHub Releases (24 Tags)
+### GitHub Releases (25 Tags)
 
 **Purpose**: Versioned data storage using GitHub Releases as a data bus. Each tag holds per-season parquet files uploaded by `torp::save_to_release()`.
 
@@ -108,7 +108,8 @@ sequenceDiagram
 | `weather-data` | Historical weather | Ad-hoc |
 | `psr-data` | PSR ratings | Daily (game days) |
 | `ps-data` | Player stat ratings | Daily (game days) |
-| `reference-data` | Reference tables | Ad-hoc |
+| `stat_ratings-data` | Per-statistic GAM ratings | Daily (game days) |
+| `reference-data` | Reference tables (stadiums, etc.) | Ad-hoc |
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -241,3 +241,9 @@ torpdata/
 | **Retrodictions** | Backfilled predictions for rounds that occurred before the prediction pipeline was running |
 | **ratings-trigger** | Repository dispatch event sent from torpdata to torp after new data is released |
 | **blog-trigger** | Repository dispatch event sent from torp to torpdata after ratings/predictions are computed |
+
+## See Also
+
+- `torpverse/ARCHITECTURE.md` -- Ecosystem overview and cross-repo orchestration
+- `torp/ARCHITECTURE.md` -- Core analytics engine architecture
+- `torpmodels/ARCHITECTURE.md` -- Model lifecycle and cache architecture

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -3,17 +3,19 @@ library(dplyr)
 
 # Load torp package for team name normalization (AFL_TEAM_ALIASES + torp_replace_teams)
 # Wrapped in tryCatch — missing deps (ggplot2, httr, lubridate) shouldn't block the pipeline
+torp_loaded <- FALSE
 torp_path <- if (dir.exists("../torp")) "../torp" else if (dir.exists("torp")) "torp" else NULL
 if (!is.null(torp_path)) {
   tryCatch({
     suppressMessages(devtools::load_all(torp_path, quiet = TRUE))
+    torp_loaded <- TRUE
     cat("Loaded torp package from:", torp_path, "\n")
   }, error = function(e) {
-    message("WARNING: Could not load torp package: ", conditionMessage(e))
-    message("Team name normalization and simulations will be skipped")
+    message("::warning::Could not load torp package: ", conditionMessage(e))
+    message("::warning::Team name normalization and simulations will be skipped")
   })
 } else {
-  warning("torp package not found — team name normalization unavailable")
+  message("::warning::torp package not found — team name normalization unavailable")
 }
 
 # Player ratings - predictive TORP ratings (career-weighted with exponential decay)
@@ -129,7 +131,7 @@ if (length(retro_files) > 0) {
 }
 
 # Normalize team names to canonical full names (e.g., "Adelaide" → "Adelaide Crows")
-if (exists("torp_replace_teams")) {
+if (torp_loaded) {
   preds$home_team <- torp_replace_teams(preds$home_team)
   preds$away_team <- torp_replace_teams(preds$away_team)
   cat("Team names normalized:", paste(sort(unique(preds$home_team)), collapse = ", "), "\n")
@@ -327,8 +329,8 @@ shots <- if (length(pbp_files) == 0) {
       distinct(match_id, .keep_all = TRUE) |>
       select(match_id, home_team_id, home_team_name, away_team_name) |>
       mutate(
-        home_team_name = if (exists("torp_replace_teams")) torp_replace_teams(home_team_name) else home_team_name,
-        away_team_name = if (exists("torp_replace_teams")) torp_replace_teams(away_team_name) else away_team_name
+        home_team_name = if (torp_loaded) torp_replace_teams(home_team_name) else home_team_name,
+        away_team_name = if (torp_loaded) torp_replace_teams(away_team_name) else away_team_name
       )
 
     pbp |>
@@ -549,7 +551,7 @@ if (length(fixtures_files) > 0) {
     # Team/venue names in fixtures_*.parquet are already normalized at scrape time
     # by load_fixtures() → .normalise_fixture_columns() in torp package.
     # Use torp_replace_teams/venues if available, otherwise trust source names.
-    norm_team  <- if (exists("torp_replace_teams"))  torp_replace_teams  else identity
+    norm_team  <- if (torp_loaded)  torp_replace_teams  else identity
     norm_venue <- if (exists("torp_replace_venues")) torp_replace_venues else identity
     fixtures_blog <- fixtures_raw |>
       dplyr::filter(!is.na(round_number)) |>
@@ -569,7 +571,7 @@ if (length(fixtures_files) > 0) {
     write_parquet(fixtures_blog, "blog/fixtures-history.parquet")
     cat("fixtures-history:", nrow(fixtures_blog), "matches\n")
   }, error = function(e) {
-    message("WARNING: Fixtures processing failed, skipping: ", conditionMessage(e))
+    message("::warning::Fixtures processing failed, skipping: ", conditionMessage(e))
   })
 } else {
   message("INFO: No fixtures files in source/ — skipping fixtures-history.parquet")
@@ -578,7 +580,7 @@ if (length(fixtures_files) > 0) {
 # Season simulations — Monte Carlo projections (depends on torp package)
 # Everything inside tryCatch so missing deps do not block the rest of the pipeline.
 # torp is already loaded at the top of the script (line 5-11) — skip redundant load_all
-if (exists("torp_replace_teams")) {
+if (torp_loaded) {
   tryCatch({
   library(data.table)
 
@@ -696,5 +698,5 @@ if (exists("torp_replace_teams")) {
           conditionMessage(e))
 })
 } else {
-  message("INFO: torp package not found — skipping simulations")
+  message("::warning::torp package not loaded — skipping simulations")
 }


### PR DESCRIPTION
## Summary
- **Fix AFL simulations**: `devtools::load_all("torp")` was silently failing in `build-blog-data.yml` because torp's Imports (ggplot2, httr, lubridate, mgcv, etc.) weren't installed. Simulations have been skipped since ~Mar 24. Added all 15 missing torp dependencies.
- **Update action versions**: checkout v4→v6, repository-dispatch v3→v4, github-script v7→v8 across 3 workflows (ahead of GitHub Node.js 20 EOL Sept 2026)

## Test plan
- [x] Manually triggered `build-blog-data.yml` on dev — check logs for `simulations: 18 teams` instead of `skipping simulations`
- [ ] Verify `afl/simulations.parquet` Last-Modified updates on R2 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)