### PR TITLE
Fix simulations pipeline, ladder normalization, pipeline hardening

### DIFF
--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -658,7 +658,7 @@ if (torp_loaded) {
     ladder <- get_afl_ladder(current_season)
     if (nrow(ladder) == 0) stop("No ladder data available")
     data.table(
-      team = ladder$team,
+      team = torp_replace_teams(ladder$team),
       current_wins = as.integer(ladder$wins),
       current_losses = as.integer(ladder$losses),
       current_pct = round(ladder$percentage, 1)


### PR DESCRIPTION
## Summary
- **Fix simulations pipeline**: add 15 missing torp package dependencies so `devtools::load_all()` succeeds in CI
- **Fix current standings merge**: normalize ladder team names via `torp_replace_teams()` so W/L/Pct joins correctly with simulation data
- **Harden build pipeline**: replace `exists("torp_replace_teams")` with explicit `torp_loaded` flag, use `::warning::` annotations for GH Actions visibility, add output validation step
- **Update GH Action versions**: checkout v4→v6, repository-dispatch v3→v4, github-script v7→v8
- **Architecture docs**: add cross-references and stat_ratings-data tag

## Test plan
- [ ] Build blog data workflow succeeds with simulations output
- [ ] All 18 teams have correct `current_wins`/`current_losses` in simulations.parquet
- [ ] Workflow summary shows no `::warning::` for torp loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)