### PR TITLE
fix: output position columns distinctly in blog parquets

### DIFF
--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -31,13 +31,10 @@ for (old_nm in names(ratings_renames)) {
   }
 }
 
-# Handle position column rename: position → position_group (torp PR #79)
-if ("position_group" %in% names(all_ratings) && !"position" %in% names(all_ratings)) {
-  all_ratings$position <- all_ratings$position_group
-}
-
 ratings <- all_ratings |>
-  select(player_id, player_name, team, position, torp, recv_epr, disp_epr,
+  select(player_id, player_name, team,
+         any_of(c("position_group", "lineup_position", "position")),
+         torp, recv_epr, disp_epr,
          spoil_epr, hitout_epr, gms, season, round,
          any_of(c("epr", "psr", "osr", "dsr"))) |>
   arrange(desc(torp))
@@ -182,11 +179,7 @@ for (old_nm in names(old_to_new)) {
 if (!"player_name" %in% names(details_raw) && all(c("first_name", "surname") %in% names(details_raw))) {
   details_raw$player_name <- paste(details_raw$first_name, details_raw$surname)
 }
-# Handle position column rename in player_details (torp PR #79)
-if ("position_group" %in% names(details_raw) && !"position" %in% names(details_raw)) {
-  details_raw$position <- details_raw$position_group
-}
-required_detail_cols <- c("player_id", "player_name", "team", "position",
+required_detail_cols <- c("player_id", "player_name", "team",
                           "jumper_number", "height_cm", "weight_kg",
                           "date_of_birth", "draft_year", "debut_year",
                           "recruited_from")
@@ -206,11 +199,11 @@ if (!"season" %in% names(details_raw)) {
   details_raw$season <- derived_season
 }
 details <- details_raw |>
-  transmute(
+  select(
     player_id,
     player_name,
     team,
-    position,
+    any_of(c("position_group", "lineup_position", "position")),
     jumper_number,
     height_cm,
     weight_kg,


### PR DESCRIPTION
## Summary
- Replaces alias approach from #50 with `any_of()` selects that pass through `position_group`, `lineup_position`, and/or `position` — whichever exist in the source parquets
- Removes `position` from `required_detail_cols` (new parquets have `position_group` instead)
- Switches `transmute` → `select` in details pipeline for consistency
- Blog pages (inthegame-blog) updated in parallel to reference `position_group` directly

## Test plan
- [ ] Merge and re-trigger `build-blog-data.yml`
- [ ] Verify blog parquets on R2 contain `position_group` column

🤖 Generated with [Claude Code](https://claude.com/claude-code)