### PR TITLE
Blog data fixes, game-logs date, position column updates

### DIFF
--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -270,8 +270,8 @@ if (length(fixtures_data_files) > 0) {
     date_lookup <- date_lookup |>
       dplyr::filter(!is.na(utc_start_time), !is.na(match_id)) |>
       dplyr::mutate(
-        date = format(as.POSIXct(utc_start_time, format = "%Y-%m-%dT%H:%M:%OS%z"),
-                      tz = "Australia/Melbourne", format = "%Y-%m-%d")
+        date = as.character(as.Date(lubridate::with_tz(
+          lubridate::ymd_hms(utc_start_time, quiet = TRUE), "Australia/Melbourne")))
       ) |>
       dplyr::select(match_id, date) |>
       dplyr::distinct(match_id, .keep_all = TRUE)
@@ -284,7 +284,7 @@ if (length(fixtures_data_files) > 0) {
   }
 } else {
   game_logs$date <- NA_character_
-  message("INFO: No fixtures parquets in data/ — date column will be NA")
+  message("INFO: No fixtures parquets in source/ or data/ — date column will be NA")
 }
 
 if (has_psv) {

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -256,6 +256,34 @@ game_logs <- game_raw |>
          any_of(c("psv", "osv", "dsv")),
          match_id) |>
   arrange(player_id, season, round)
+
+# Join date from fixtures (data/ has fixtures_YYYY.parquet with match_id + utc_start_time)
+fixtures_data_files <- list.files("data", pattern = "^fixtures_.*\\.parquet$", full.names = TRUE)
+if (length(fixtures_data_files) > 0) {
+  date_lookup <- lapply(fixtures_data_files, function(f) {
+    tryCatch(read_parquet(f, col_select = c("match_id", "utc_start_time")), error = function(e) NULL)
+  }) |> dplyr::bind_rows()
+  if (nrow(date_lookup) > 0 && "utc_start_time" %in% names(date_lookup)) {
+    date_lookup <- date_lookup |>
+      dplyr::filter(!is.na(utc_start_time), !is.na(match_id)) |>
+      dplyr::mutate(
+        date = format(as.POSIXct(utc_start_time, format = "%Y-%m-%dT%H:%M:%OS%z"),
+                      tz = "Australia/Melbourne", format = "%Y-%m-%d")
+      ) |>
+      dplyr::select(match_id, date) |>
+      dplyr::distinct(match_id, .keep_all = TRUE)
+    game_logs <- dplyr::left_join(game_logs, date_lookup, by = "match_id")
+    cat("game-logs: date column added from fixtures (",
+        sum(!is.na(game_logs$date)), "/", nrow(game_logs), "rows matched)\n")
+  } else {
+    game_logs$date <- NA_character_
+    message("INFO: fixtures parquets lack utc_start_time — date column will be NA")
+  }
+} else {
+  game_logs$date <- NA_character_
+  message("INFO: No fixtures parquets in data/ — date column will be NA")
+}
+
 if (has_psv) {
   cat("game-logs: PSV/OSV/DSV columns included\n")
 } else {

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -257,8 +257,11 @@ game_logs <- game_raw |>
          match_id) |>
   arrange(player_id, season, round)
 
-# Join date from fixtures (data/ has fixtures_YYYY.parquet with match_id + utc_start_time)
-fixtures_data_files <- list.files("data", pattern = "^fixtures_.*\\.parquet$", full.names = TRUE)
+# Join date from fixtures (CI downloads to source/, local dev has them in data/)
+fixtures_data_files <- list.files("source", pattern = "^fixtures_.*\\.parquet$", full.names = TRUE)
+if (length(fixtures_data_files) == 0) {
+  fixtures_data_files <- list.files("data", pattern = "^fixtures_.*\\.parquet$", full.names = TRUE)
+}
 if (length(fixtures_data_files) > 0) {
   date_lookup <- lapply(fixtures_data_files, function(f) {
     tryCatch(read_parquet(f, col_select = c("match_id", "utc_start_time")), error = function(e) NULL)


### PR DESCRIPTION
## Summary
- **Position columns**: output `position_group` and `lineup_position` distinctly in blog parquets
- **Game-logs**: add date column from fixtures join
- **Blog data**: coalesce old `home_rating` → `home_epr` column rename
- **Ladder**: normalize team names in current standings merge
- **Pipeline hardening**: torp_loaded flag, `::warning::` annotations, output validation
- **Simulations**: fix pipeline and update GH Action versions
- **R2 upload**: add retry logic for transient failures
- **Dependabot**: enable for GitHub Actions updates

## Test plan
- [ ] `build-blog-data.yml` workflow runs successfully
- [ ] Blog parquets contain correct column names

🤖 Generated with [Claude Code](https://claude.com/claude-code)