### PR TITLE
Ship player finishing skill to R2 via build-blog-data

### DIFF
--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -141,15 +141,11 @@ jobs:
           fi
 
           # Shot GAM + player-name lookup (for player finishing-skill extraction — optional)
-          if gh release download core-models -p "shot_ocat_mdl.rds" -D source -R peteowen1/torpmodels; then
-            echo "Downloaded shot_ocat_mdl.rds from torpmodels"
+          if gh release download core-models -p "shot_ocat_mdl.rds" -p "shot_player_df.rds" \
+               -D source -R peteowen1/torpmodels; then
+            echo "Downloaded shot model assets from torpmodels"
           else
-            echo "::warning::shot_ocat_mdl.rds not available — player-finishing will be skipped"
-          fi
-          if gh release download core-models -p "shot_player_df.rds" -D source -R peteowen1/torpmodels; then
-            echo "Downloaded shot_player_df.rds from torpmodels"
-          else
-            echo "::warning::shot_player_df.rds not available — finishing names may be NA for retired players"
+            echo "::warning::shot model assets not available — player-finishing will be skipped"
           fi
 
       - name: Aggregate

--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -140,6 +140,18 @@ jobs:
             echo "::warning::No fixtures data available — fixtures-history will be skipped"
           fi
 
+          # Shot GAM + player-name lookup (for player finishing-skill extraction — optional)
+          if gh release download core-models -p "shot_ocat_mdl.rds" -D source -R peteowen1/torpmodels; then
+            echo "Downloaded shot_ocat_mdl.rds from torpmodels"
+          else
+            echo "::warning::shot_ocat_mdl.rds not available — player-finishing will be skipped"
+          fi
+          if gh release download core-models -p "shot_player_df.rds" -D source -R peteowen1/torpmodels; then
+            echo "Downloaded shot_player_df.rds from torpmodels"
+          else
+            echo "::warning::shot_player_df.rds not available — finishing names may be NA for retired players"
+          fi
+
       - name: Aggregate
         run: Rscript scripts/build_blog_data.R
 
@@ -192,7 +204,7 @@ jobs:
           done
 
           # Optional — warn but don't fail
-          for f in simulations.parquet shots.parquet game-stats.parquet player-skills.parquet; do
+          for f in simulations.parquet shots.parquet game-stats.parquet player-skills.parquet player-finishing.parquet; do
             if [ ! -f "blog/$f" ]; then
               echo "::warning::Optional output blog/$f was not produced"
             fi

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -459,24 +459,21 @@ if (torp_loaded && file.exists(shot_mdl_path)) {
   suppressPackageStartupMessages(library(mgcv))
   tryCatch({
     shot_mdl <- readRDS(shot_mdl_path)
-    finishing <- extract_player_xg_skill(shot_model = shot_mdl)
+    finishing <- extract_player_xg_skill(shot_model = shot_mdl) |> as.data.frame()
     if (!is.null(finishing) && nrow(finishing) > 0) {
       # Backfill names from training-time mapping (covers retired players that
       # load_player_details(current season) misses)
       player_df_path <- "source/shot_player_df.rds"
       if (file.exists(player_df_path)) {
-        spd <- readRDS(player_df_path)
-        finishing <- as.data.frame(finishing) |>
-          left_join(
-            transmute(spd,
-                      player_id = as.character(player_id_shot),
-                      player_name_train = player_name_shot),
-            by = "player_id"
-          ) |>
+        name_lookup <- readRDS(player_df_path) |>
+          transmute(player_id = as.character(player_id_shot),
+                    player_name_train = player_name_shot)
+        finishing <- finishing |>
+          left_join(name_lookup, by = "player_id") |>
           mutate(player_name = coalesce(player_name, player_name_train)) |>
           select(-player_name_train)
       }
-      finishing_blog <- as.data.frame(finishing) |>
+      finishing_blog <- finishing |>
         filter(player_id != "Other", !is.na(player_id)) |>
         transmute(
           player_id,

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -485,6 +485,7 @@ if (torp_loaded && file.exists(shot_mdl_path)) {
           n_shots = as.integer(n_shots)
         ) |>
         arrange(desc(xg_skill))
+      dir.create("blog", showWarnings = FALSE)
       write_parquet(finishing_blog, "blog/player-finishing.parquet")
       cat("player-finishing:", nrow(finishing_blog), "players\n")
     } else {

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -450,6 +450,53 @@ if (!is.null(shots) && "match_id" %in% names(shots) && "team_id" %in% names(shot
   })
 }
 
+# Player finishing skill — per-player random effects from the shot GAM
+# Optional: requires shot model in source/ and torp loaded
+shot_mdl_path <- "source/shot_ocat_mdl.rds"
+if (torp_loaded && file.exists(shot_mdl_path)) {
+  tryCatch({
+    # mgcv must be on the search path so stats::coef/vcov dispatch to coef.gam/vcov.gam
+    suppressPackageStartupMessages(library(mgcv))
+    shot_mdl <- readRDS(shot_mdl_path)
+    finishing <- extract_player_xg_skill(shot_model = shot_mdl)
+    if (!is.null(finishing) && nrow(finishing) > 0) {
+      # Backfill names from training-time mapping (covers retired players that
+      # load_player_details(current season) misses)
+      player_df_path <- "source/shot_player_df.rds"
+      if (file.exists(player_df_path)) {
+        spd <- readRDS(player_df_path)
+        finishing <- as.data.frame(finishing) |>
+          left_join(
+            transmute(spd,
+                      player_id = as.character(player_id_shot),
+                      player_name_train = player_name_shot),
+            by = "player_id"
+          ) |>
+          mutate(player_name = coalesce(player_name, player_name_train)) |>
+          select(-player_name_train)
+      }
+      finishing_blog <- as.data.frame(finishing) |>
+        filter(player_id != "Other", !is.na(player_id)) |>
+        transmute(
+          player_id,
+          player_name,
+          xg_skill = round(xg_skill, 4),
+          xg_skill_se = round(xg_skill_se, 4),
+          n_shots = as.integer(n_shots)
+        ) |>
+        arrange(desc(xg_skill))
+      write_parquet(finishing_blog, "blog/player-finishing.parquet")
+      cat("player-finishing:", nrow(finishing_blog), "players\n")
+    } else {
+      message("INFO: extract_player_xg_skill returned no rows — skipping player-finishing.parquet")
+    }
+  }, error = function(e) {
+    message("::warning::Player finishing extraction failed: ", conditionMessage(e))
+  })
+} else {
+  message("INFO: Shot model or torp not available — skipping player-finishing.parquet")
+}
+
 # Match events from PBP — per-season event-level EPV data for match-events page
 # Optional: uses same pbp_files as shots
 if (length(pbp_files) > 0) {

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -451,12 +451,13 @@ if (!is.null(shots) && "match_id" %in% names(shots) && "team_id" %in% names(shot
 }
 
 # Player finishing skill — per-player random effects from the shot GAM
-# Optional: requires shot model in source/ and torp loaded
 shot_mdl_path <- "source/shot_ocat_mdl.rds"
 if (torp_loaded && file.exists(shot_mdl_path)) {
+  # mgcv must be attached so stats::coef/vcov dispatch to coef.gam/vcov.gam.
+  # Loaded outside the tryCatch so a missing install fails loudly rather than
+  # masquerading as a missing optional input.
+  suppressPackageStartupMessages(library(mgcv))
   tryCatch({
-    # mgcv must be on the search path so stats::coef/vcov dispatch to coef.gam/vcov.gam
-    suppressPackageStartupMessages(library(mgcv))
     shot_mdl <- readRDS(shot_mdl_path)
     finishing <- extract_player_xg_skill(shot_model = shot_mdl)
     if (!is.null(finishing) && nrow(finishing) > 0) {
@@ -485,6 +486,9 @@ if (torp_loaded && file.exists(shot_mdl_path)) {
           n_shots = as.integer(n_shots)
         ) |>
         arrange(desc(xg_skill))
+      # Guard against a duplicated player_id in shot_player_df.rds fanning out
+      # the join and shipping duplicates to R2
+      stopifnot(!anyDuplicated(finishing_blog$player_id))
       dir.create("blog", showWarnings = FALSE)
       write_parquet(finishing_blog, "blog/player-finishing.parquet")
       cat("player-finishing:", nrow(finishing_blog), "players\n")


### PR DESCRIPTION
## Summary
- Adds `blog/player-finishing.parquet` to the build-blog-data pipeline by extracting per-player random effects from the shot GAM (`shot_ocat_mdl.rds`) via `torp::extract_player_xg_skill()`
- Workflow downloads `shot_ocat_mdl.rds` and `shot_player_df.rds` from `peteowen1/torpmodels` `core-models` release; player names backfilled from `shot_player_df` so retired players aren't NA
- Filters out the `"Other"` lump bucket (modelling artifact, not a real player)

## Test plan
- [x] Local smoke test: 628 rows, sensible top (Wright, Fritsch, Fogarty) and bottom (Ugle-Hagan, Naughton, Petracca)
- [x] Dispatched on dev: run [24595152100](https://github.com/peteowen1/torpdata/actions/runs/24595152100) — succeeded, "player-finishing: 627 players"
- [x] R2 verified: HTTP 200 at `inthegame-data/afl/player-finishing.parquet` (24,352 bytes)
- [ ] After merge: next `repository_dispatch: blog-trigger` from torp's daily pipeline will pick up this code on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)