### PR TITLE
fix(release): wait for release-list propagation before dispatching torp

### DIFF
--- a/.github/workflows/daily-data-release.yml
+++ b/.github/workflows/daily-data-release.yml
@@ -196,6 +196,16 @@ jobs:
           echo "afl_season=$AFL_SEASON" >> $GITHUB_OUTPUT
           echo "afl_round=$AFL_ROUND" >> $GITHUB_OUTPUT
 
+      # Wait for GitHub's release-list endpoint to reflect the new release
+      # before dispatching. verify_release confirms the asset is queryable
+      # via /releases/tags/{tag}, but piggyback (used by torp) hits GET
+      # /releases (the list endpoint), which has its own cache that lags
+      # behind by ~10-30s. Without this delay torp can fire a rare
+      # "No GitHub releases found for peteowen1/torpdata" failure.
+      - name: Wait for release-list propagation
+        if: steps.verify_release.outputs.release_verified == 'true'
+        run: sleep 30
+
       - name: Dispatch ratings trigger to torp
         if: steps.verify_release.outputs.release_verified == 'true'
         uses: peter-evans/repository-dispatch@v4

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -242,8 +242,24 @@ if (length(missing_game_cols) > 0) {
        paste(missing_game_cols, collapse = ", "))
 }
 has_psv <- "psv" %in% names(game_raw)
+# Per-game EPV columns — source of truth uses epv, recv_epv, etc. For some
+# time we aliased these to torp/torp_recv/... on the blog parquet because
+# the blog column vocabulary used torp_* for per-game values. That was
+# confusing — per-game value is EPV (Expected Possession Value), while
+# the plain "torp" column on the *ratings* parquet is the season TORP
+# rating (EPR + PSR blend). So the game-logs parquet now ships with
+# epv/epv_recv/... as the canonical names. The torp/torp_* aliases remain
+# as a transition shim for any consumer (blog, notebooks) still reading
+# the old names; once those migrate, drop this block.
 game_logs <- game_raw |>
   mutate(
+    # Canonical (new) names — same values
+    epv = epv,
+    epv_recv = recv_epv,
+    epv_disp = disp_epv,
+    epv_spoil = spoil_epv,
+    epv_hitout = hitout_epv,
+    # Back-compat aliases — drop after all consumers migrate
     torp = epv,
     torp_recv = recv_epv,
     torp_disp = disp_epv,
@@ -251,6 +267,7 @@ game_logs <- game_raw |>
     torp_hitout = hitout_epv
   ) |>
   select(player_id, player_name, season, round, team, opp,
+         epv, epv_recv, epv_disp, epv_spoil, epv_hitout,
          torp, torp_recv, torp_disp, torp_spoil, torp_hitout,
          any_of(c("wp_credit", "wp_disp_credit", "wp_recv_credit")),
          any_of(c("psv", "osv", "dsv")),


### PR DESCRIPTION
## Summary

torp's daily-ratings-predictions.yml uses piggyback to read torpdata releases. piggyback hits `GET /releases` (the list endpoint), which has its own cache lag of ~10–30s after a new release is published — distinct from `/releases/tags/{tag}` which the verify step uses.

This produced one observed transient failure on 2026-04-27: the verify step passed, the dispatch fired, and torp's piggyback call landed in the propagation gap with `! No GitHub releases found for "peteowen1/torpdata"!`. Two other runs the same day succeeded.

Adds a 30s sleep between verify and dispatch to close the window.

## Why not a retry in torp's R code

Considered, but the symptom is purely time-based eventual consistency — adding ~30s once, in the dispatcher, is simpler than wrapping every piggyback call in torp.

## Test plan

- [ ] Wait for next scheduled torpdata Daily Data Release run
- [ ] Confirm new "Wait for release-list propagation" step shows in run log
- [ ] Confirm downstream torp Daily Ratings & Predictions run completes successfully