### PR TITLE
fix(blog-data): install piggyback for skills-history publish (#87)

### DIFF
--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -41,6 +41,7 @@ jobs:
             any::curl
             any::digest
             any::gh
+            any::piggyback
             any::jsonlite
             any::purrr
             any::rlang


### PR DESCRIPTION
Hotfix for #60: the skills-history publish step needs `piggyback` (a torp Suggests) to upload, but it wasn't in this job's dep list, so `save_to_release()` errored (masked by warn-don't-fail). Adds `any::piggyback`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)