### PR TITLE
Fable 5 review fixes: concurrency guards + doc resync

### DIFF
--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -5,6 +5,10 @@ on:
     types: [blog-trigger]
   workflow_dispatch:
 
+concurrency:
+  group: daily-release
+  cancel-in-progress: false
+
 permissions:
   contents: write   # write: re-publishes player_skills_history.parquet to the player_skills-data release
 

--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Download source parquets
         env:
           GH_TOKEN: ${{ github.token }}
+          WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
         run: |
           mkdir -p source
           if ! gh release download team_ratings-data -p "team_ratings.parquet" -D source; then
@@ -142,7 +143,9 @@ jobs:
           fi
 
           # Shot GAM + player-name lookup (for player finishing-skill extraction — optional)
-          if gh release download core-models -p "shot_ocat_mdl.rds" -p "shot_player_df.rds" \
+          # Uses WORKFLOW_PAT: github.token is scoped to this repo and can't read
+          # torpmodels if that repo is ever made private.
+          if GH_TOKEN="${WORKFLOW_PAT}" gh release download core-models -p "shot_ocat_mdl.rds" -p "shot_player_df.rds" \
                -D source -R peteowen1/torpmodels; then
             echo "Downloaded shot model assets from torpmodels"
           else

--- a/.github/workflows/daily-data-release.yml
+++ b/.github/workflows/daily-data-release.yml
@@ -46,11 +46,12 @@ on:
 
 concurrency:
   group: daily-release
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   GITHUB_PAT: ${{ secrets.WORKFLOW_PAT }}
   R_KEEP_PKG_SOURCE: yes
+  piggyback_cache_duration: 1
 
 jobs:
   release-data:
@@ -113,6 +114,9 @@ jobs:
             cat(paste0('release_done=', tolower(release_done), '\n'),
                 file = Sys.getenv('GITHUB_OUTPUT'), append = TRUE)
             cat(paste0('release_mode=', result, '\n'),
+                file = Sys.getenv('GITHUB_OUTPUT'), append = TRUE)
+            failures <- attr(result, 'failures')
+            cat(paste0('failures=', paste(failures, collapse = ','), '\n'),
                 file = Sys.getenv('GITHUB_OUTPUT'), append = TRUE)
           "
         env:
@@ -259,6 +263,48 @@ jobs:
             echo "No new games or lineup changes detected. Release skipped."
             echo "This is expected during the off-season or between rounds."
           } >> $GITHUB_STEP_SUMMARY
+
+      - name: Notify on partial data-type failures
+        if: steps.daily_release.outputs.failures != ''
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const title = 'Daily Data Release - Partial Failures';
+            const failures = '${{ steps.daily_release.outputs.failures }}';
+            const body = `Daily data release completed but some data types failed to update on ${new Date().toISOString()}.
+
+            **Failed:** ${failures}
+            **Season:** ${{ steps.release_info.outputs.afl_season || 'unknown' }}
+            **Round:** ${{ steps.release_info.outputs.afl_round || 'unknown' }}
+
+            The release still uploaded successfully for other data types and downstream
+            steps ran normally. Check the [workflow run](${context.payload.repository.html_url}/actions/runs/${context.runId}) for the specific errors.`;
+
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'automation,bug'
+            });
+
+            const existingIssue = issues.data.find(i => i.title === title);
+
+            if (existingIssue) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existingIssue.number,
+                body: `Recurred on ${new Date().toISOString()}: ${failures}\n\n[View run](${context.payload.repository.html_url}/actions/runs/${context.runId})`
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: title,
+                body: body,
+                labels: ['bug', 'automation']
+              });
+            }
 
       - name: Notify on failure
         if: failure()

--- a/.github/workflows/lineup-predictions.yml
+++ b/.github/workflows/lineup-predictions.yml
@@ -14,6 +14,11 @@ on:
 env:
   GITHUB_PAT: ${{ secrets.WORKFLOW_PAT }}
   R_KEEP_PKG_SOURCE: yes
+  piggyback_cache_duration: 1
+
+concurrency:
+  group: daily-release
+  cancel-in-progress: false
 
 jobs:
   check-lineups:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -64,10 +64,10 @@ sequenceDiagram
     participant R2 as Cloudflare R2
 
     CRON->>TD: daily-data-release.yml
-    TD->>TORP: torp::run_daily_release()
+    TD->>TORP: run_daily_release() (sourced from data-raw/01-data/daily_release.R)
     TORP->>TORP: has_new_games() check
     alt New games found
-        TORP->>GH: Upload parquets (24 release tags)
+        TORP->>GH: Upload parquets (22 release tags)
         TD->>TORP: repository_dispatch (ratings-trigger)
         TORP->>TORP: EPR pipeline + predictions
         TORP->>GH: Upload ratings + predictions
@@ -81,7 +81,7 @@ sequenceDiagram
 
 ## Components
 
-### GitHub Releases (25 Tags)
+### GitHub Releases (22 Tags)
 
 **Purpose**: Versioned data storage using GitHub Releases as a data bus. Each tag holds per-season parquet files uploaded by `torp::save_to_release()`.
 
@@ -107,9 +107,11 @@ sequenceDiagram
 | `ep_wp_chart-data` | Lightweight PBP for charting | Daily (game days) |
 | `weather-data` | Historical weather | Ad-hoc |
 | `psr-data` | PSR ratings | Daily (game days) |
-| `ps-data` | Player stat ratings | Daily (game days) |
-| `stat_ratings-data` | Per-statistic GAM ratings | Daily (game days) |
+| `player_stat_ratings-data` | Per-statistic player ratings | Daily (game days) |
 | `reference-data` | Reference tables (stadiums, etc.) | Ad-hoc |
+
+The 58 per-statistic GAMs themselves (not the ratings derived from them) are
+released via torpmodels' `stat-models` tag, not stored on torpdata.
 
 ---
 
@@ -130,7 +132,7 @@ sequenceDiagram
 **Manual Inputs**: `force_release` (skip new-games check), `rebuild_aggregates` (full rebuild)
 
 **Steps**:
-1. Run `torp::run_daily_release(force)` -- returns `'full'`, `'team_only'`, or `'none'`
+1. Run `run_daily_release(force)` (not an exported torp function -- sourced from `data-raw/01-data/daily_release.R`) -- returns `'full'`, `'team_only'`, or `'none'`
 2. Verify release freshness (critical files updated within 24 hours)
 3. Optional: rebuild aggregated files
 4. Dispatch `ratings-trigger` to torp with season/round payload
@@ -149,8 +151,8 @@ sequenceDiagram
 **Schedule**: Wed/Thu 7-10 PM AEST (4 cron jobs) + Friday 8 AM AEST
 
 **Steps**:
-1. Run `torp::has_new_team_data()` -- returns TRUE/FALSE
-2. If TRUE: run `torp::run_daily_release()` in team-only mode
+1. Run `has_new_team_data()` (sourced from `data-raw/01-data/daily_release.R`, not exported) -- returns TRUE/FALSE
+2. If TRUE: run `run_daily_release()` in team-only mode
 3. Dispatch `ratings-trigger` to torp
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,11 @@ Each data type has its own GitHub release tag:
 - `player_game-data`, `results-data`, `xg-data`, `teams-data`
 - `predictions`, `ratings-data`, `team_ratings-data`
 - `player_game_ratings-data`, `player_season_ratings-data`
-- `weather-data`, `stat_ratings-data`, `stat-models`
+- `weather-data`, `injury-data`, `retrodictions`, `reference-data`
+- `player_stat_ratings-data`, `player_skills-data`, `psr-data`
+
+(The 58 per-stat GAMs and core EP/WP/shot/match models are released via
+torpmodels' `stat-models` and `core-models` tags, not stored here.)
 
 ## How Data Gets Here
 
@@ -42,8 +46,8 @@ Runs daily at 16:00 UTC (2:00 AM AEST). Can also be manually dispatched with `fo
 
 **Flow:**
 1. Checks out torpdata + torp, installs R dependencies
-2. Runs `run_daily_release()` from torp — returns TRUE/FALSE based on whether new games exist
-3. R writes `release_done=true|false` to `$GITHUB_OUTPUT` (written from R via `cat(file=Sys.getenv('GITHUB_OUTPUT'))` to avoid stdout contamination from `devtools::load_all()`)
+2. Runs `run_daily_release()` (sourced from torp's `data-raw/01-data/daily_release.R`, not an exported function) — returns `'full'`, `'team_only'`, or `'none'`
+3. R writes `release_done=true|false` to `$GITHUB_OUTPUT` (derived from the `'none'` vs not check; written via `cat(file=Sys.getenv('GITHUB_OUTPUT'))` to avoid stdout contamination from `devtools::load_all()`)
 4. Verification, release info, and summary steps are gated on `release_done == 'true'`
 5. If data was released and verified, dispatches `ratings-trigger` to torp
 6. Off-season: skips gracefully with a "No New Data" summary


### PR DESCRIPTION
## Summary
- Concurrency guards on release-writing workflows (build-blog-data, daily-data-release, lineup-predictions) to stop the multi-fire race the review caught live in a sister verse
- ARCHITECTURE.md / CLAUDE.md doc drift resync

## Context
Part of a cross-verse Fable 5 deep-review pass (torpverse/torp/FABLE-REVIEW.md). Paired with torp's dev branch (already in open PR #100).

## Test plan
- [x] CI green on push to dev (Build blog data)