### PR TITLE
CI: install rvest in build-blog-data (companion to torp#105)

### DIFF
--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -29,6 +29,12 @@ jobs:
         with:
           use-public-rspm: true
 
+      # torpmodels (GitHub, not CRAN — via its "peteowen1/torpmodels" pak spec below)
+      # is needed so the season-sim block's team_residuals = "auto" can actually call
+      # torpmodels::load_torp_model("match_gams") inside torp:::.extract_team_residuals().
+      # Without it that call errors (caught, degrades to NULL) and residual_mean/
+      # residual_se silently come back all-zero in both simulations.parquet and
+      # team-strength.parquet.
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           packages: |
@@ -55,6 +61,7 @@ jobs:
             any::tibble
             any::tidyselect
             any::withr
+            peteowen1/torpmodels
 
       - name: Download source parquets
         env:
@@ -239,7 +246,7 @@ jobs:
           done
 
           # Optional — warn but don't fail
-          for f in simulations.parquet shots.parquet game-stats.parquet player-skills.parquet player-skills-history.parquet player-finishing.parquet; do
+          for f in simulations.parquet team-strength.parquet shots.parquet game-stats.parquet player-skills.parquet player-skills-history.parquet player-finishing.parquet; do
             if [ ! -f "blog/$f" ]; then
               echo "::warning::Optional output blog/$f was not produced"
             fi

--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -49,6 +49,7 @@ jobs:
             any::jsonlite
             any::purrr
             any::rlang
+            any::rvest
             any::stringi
             any::stringr
             any::tibble

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,9 @@ Blog/analysis data generation workflow. Manually dispatched — runs `scripts/bu
 
 Blog data is uploaded to the `inthegame-data` R2 bucket under the `afl/` prefix via wrangler CLI in `build-blog-data.yml`.
 
-**Files uploaded to `afl/`:** `ratings.parquet`, `team-ratings.parquet`, `predictions.parquet`, `player-details.parquet`, `game-logs.parquet`, `game-stats.parquet`, `shots.parquet`, `simulations.parquet`, `player-skills.parquet`, `player-finishing.parquet`, `afl_teams_YYYY.parquet`, `match_events_YYYY.parquet` (per season)
+**Files uploaded to `afl/`:** `ratings.parquet`, `team-ratings.parquet`, `predictions.parquet`, `player-details.parquet`, `game-logs.parquet`, `game-stats.parquet`, `shots.parquet`, `simulations.parquet`, `team-strength.parquet`, `player-skills.parquet`, `player-finishing.parquet`, `afl_teams_YYYY.parquet`, `match_events_YYYY.parquet` (per season)
+
+**`team-strength.parquet`** (added for the blog's browser finals sim, mirrors panna's `wc2026_team_strength.parquet`): one row per team with `torp`, the match-GAM `residual_mean`/`residual_se` (same object `season_sim.R`'s `simulate_afl_season()` samples from per-sim — reused via `sim_results$original_ratings`, so it can never diverge from the R sim), and two DISPLAY-ONLY Bradley-Terry columns — `bt_results`/`bt_results_se` (logistic/glm BT fit on this season's completed games) and `bt_model` (cross-entropy BT fit on the model's predicted `home_win_prob`, mirroring `panna::fit_bt_ratings()`). Built in `scripts/build_blog_data.R`'s season-sim block; needs `torpmodels` installed in CI (added to `build-blog-data.yml`'s package list) or `.extract_team_residuals()` silently degrades to all-zero residuals.
 
 **Name rename at build:** `build_blog_data.R` reads the `torp_`-prefixed release assets (e.g. `source/torp_ratings.parquet` from the `ratings-data` release) and writes the unprefixed blog/R2 names (`ratings.parquet`). So a `torp_*.parquet` on the release/disk side maps to `*.parquet` (no prefix) in `blog/` and R2 — don't expect the names to match across the boundary.
 

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -1070,16 +1070,104 @@ if (torp_loaded) {
     }
     strength_dt <- merge(strength_dt, bt_model_dt, by = "team", all.x = TRUE)
 
+    # --- pts_results / pts_model: POINTS-SCALE team strengths, fit by plain
+    # least squares directly on match MARGINS — a Massey-style rating, as
+    # opposed to bt_results/bt_model's log-odds win/loss scale above. The
+    # log-odds scale is kept as-is (it's the right scale for win-prob/sim
+    # transforms); this points scale exists purely for a "worth about +X
+    # points vs average" display number, sitting alongside torp/residual_mean
+    # which are already points-scale. DISPLAY/REFERENCE ONLY — never a sim
+    # input, same as the bt_* columns.
+    #
+    # Model: margin_home = home_adv + s_home - s_away + error. Reuses the
+    # same design-matrix construction as bt_results above (reference-team
+    # column dropped to identify the fit, i.e. s_ref pinned to 0 pre-fit),
+    # fit via lm() (closed-form least squares — margin is already a
+    # continuous points scale, no logit/draw machinery needed), then
+    # strengths are re-centered to sum-to-zero (mean-subtracted) post-fit so
+    # "s_i" reads as points above/below a league-average team. This
+    # pin-then-recenter identification is algebraically equivalent to a
+    # sum-to-zero contrast constraint baked into the design matrix — simpler
+    # to code and identical result for the *point estimates* (recentering is
+    # just a location shift); the standard errors are, as with bt_results,
+    # reported relative to the pre-recentering reference team as a cheap
+    # approximation.
+    .fit_margin_strength <- function(games_df, margin_col) {
+      games_df <- games_df[!is.na(games_df[[margin_col]]), ]
+      teams <- sort(unique(c(games_df$home_team, games_df$away_team)))
+      if (length(teams) < 2 || nrow(games_df) < 2) return(NULL)
+      ref_team <- teams[1]
+      other_teams <- teams[-1]
+      safe_names <- make.names(other_teams, unique = TRUE)
+      X <- matrix(0, nrow = nrow(games_df), ncol = length(other_teams),
+                  dimnames = list(NULL, safe_names))
+      for (i in seq_len(nrow(games_df))) {
+        hi <- match(games_df$home_team[i], other_teams)
+        ai <- match(games_df$away_team[i], other_teams)
+        if (!is.na(hi)) X[i, hi] <- X[i, hi] + 1
+        if (!is.na(ai)) X[i, ai] <- X[i, ai] - 1
+      }
+      lm_df <- as.data.frame(X)
+      lm_df$home_adv <- 1
+      lm_df$margin <- games_df[[margin_col]]
+      fit <- stats::lm(margin ~ . - 1, data = lm_df)
+      co <- summary(fit)$coefficients
+      est <- co[safe_names, "Estimate"];   names(est) <- other_teams
+      se  <- co[safe_names, "Std. Error"]; names(se)  <- other_teams
+      full_est <- c(setNames(0, ref_team), est)
+      full_se  <- c(setNames(NA_real_, ref_team), se)
+      full_est <- full_est - mean(full_est)
+      list(
+        strength = data.table::data.table(team = names(full_est),
+                                          strength    = round(as.numeric(full_est), 3),
+                                          strength_se = round(as.numeric(full_se), 3)),
+        home_adv = round(unname(co["home_adv", "Estimate"]), 3)
+      )
+    }
+
+    pts_results_fit <- tryCatch(.fit_margin_strength(season_played, "actual_margin"),
+                                error = function(e) NULL)
+    pts_results_dt <- data.table::data.table(team = strength_dt$team,
+                                             pts_results = NA_real_, pts_results_se = NA_real_)
+    if (!is.null(pts_results_fit)) {
+      pts_results_dt <- data.table::copy(pts_results_fit$strength)
+      data.table::setnames(pts_results_dt, c("strength", "strength_se"),
+                           c("pts_results", "pts_results_se"))
+      cat("pts_results home advantage:", pts_results_fit$home_adv, "points\n")
+    }
+    strength_dt <- merge(strength_dt, pts_results_dt, by = "team", all.x = TRUE)
+
+    # pred_margin across the FULL season fixture set (played + future rounds)
+    # — the match model's own implied points-above-average per team. Same
+    # 612-row directed-matchup-table caveat as bt_model above applies here.
+    pts_model_fit <- tryCatch(.fit_margin_strength(season_fixtures, "pred_margin"),
+                              error = function(e) NULL)
+    pts_model_dt <- data.table::data.table(team = strength_dt$team,
+                                           pts_model = NA_real_, pts_model_se = NA_real_)
+    pts_home_adv_val <- NA_real_
+    if (!is.null(pts_model_fit)) {
+      pts_model_dt <- data.table::copy(pts_model_fit$strength)
+      data.table::setnames(pts_model_dt, c("strength", "strength_se"),
+                           c("pts_model", "pts_model_se"))
+      pts_home_adv_val <- pts_model_fit$home_adv
+      cat("pts_model home advantage:", pts_home_adv_val, "points\n")
+    }
+    strength_dt <- merge(strength_dt, pts_model_dt, by = "team", all.x = TRUE)
+    strength_dt[, pts_home_adv := pts_home_adv_val]
+
     strength_dt[, season := current_season]
     strength_dt[, round := latest_round]
     strength_dt[, updated := as.character(Sys.time())]
     data.table::setcolorder(strength_dt, c("team", "torp", "residual_mean", "residual_se",
                                            "bt_results", "bt_results_se", "bt_model",
+                                           "pts_results", "pts_results_se",
+                                           "pts_model", "pts_model_se", "pts_home_adv",
                                            "season", "round", "updated"))
 
     write_parquet(as.data.frame(strength_dt), "blog/team-strength.parquet")
     cat("team-strength:", nrow(strength_dt), "teams\n")
-    print(strength_dt[order(-bt_results), .(team, torp, residual_mean, bt_results, bt_model)])
+    print(strength_dt[order(-bt_results), .(team, torp, residual_mean, bt_results, bt_model,
+                                             pts_results, pts_model)])
   }, error = function(e) {
     message("::warning::Team-strength export failed, skipping team-strength.parquet: ",
             conditionMessage(e))

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -960,6 +960,130 @@ if (torp_loaded) {
 
   write_parquet(as.data.frame(sim_output), "blog/simulations.parquet")
   cat("simulations:", nrow(sim_output), "teams\n")
+
+  # --- Team strength — small residual/BT reference table for the browser sim ---
+  # Mirrors the World Cup's wc2026_team_strength.parquet (pannaverse/panna
+  # data-raw/match-predictions-opta/12_export_wc2026_blog.R). The blog's
+  # browser-side AFL finals simulator ports torp's margin formula in JS but has
+  # no access to R/mgcv, so it has been missing the per-team GAM quality
+  # residual entirely (e.g. Fremantle overperforms its torp rating by several
+  # points/game in 2026) — this export lets the browser sim add that term.
+  # In its own nested tryCatch so a BT-fit hiccup can't take out simulations.parquet.
+  tryCatch({
+    # sim_results$original_ratings IS prep$sim_teams from prepare_sim_data()
+    # (torp/R/season_sim.R) — the exact team/torp/residual_mean/residual_se the
+    # season sim itself samples from per-sim (team_residuals = "auto" ->
+    # .extract_team_residuals()). Reusing it here means this export can never
+    # diverge from what the sim uses. residual_mean/residual_se ARE meant to be
+    # consumed as a sim input by the browser sim (that's the point of this
+    # export) — unlike bt_results/bt_model below, which are DISPLAY /
+    # REFERENCE ONLY and must never be fed into any sim (R or browser).
+    strength_dt <- data.table::as.data.table(sim_results$original_ratings)
+    strength_dt[, team := torp_replace_teams(team)]
+    strength_dt <- strength_dt[, .(team, torp, residual_mean, residual_se)]
+
+    # --- bt_results: logistic/glm Bradley-Terry fit on THIS season's completed
+    # games (win = 1, loss = 0, draw = 0.5 — AFL draws are rare, ~1 in 300
+    # games; folding them in at 0.5 avoids discarding the odd one rather than
+    # needing a Davidson draw parameter), with a fixed home-ground intercept.
+    # DISPLAY/REFERENCE ONLY — never a sim input. Team strengths are identified
+    # against an arbitrary reference team (coefficient pinned to 0 pre-fit),
+    # then re-centered to mean 0 post-fit for interpretability and side-by-side
+    # comparability with bt_model (mirrors the mean-centering panna's
+    # fit_bt_ratings() does). bt_results_se is the glm standard error relative
+    # to the (pre-centering) reference team, reported as-is — a cheap
+    # approximation that doesn't correct for the recentering covariance, fine
+    # for a display-only column.
+    season_played <- preds[preds$season == current_season & !is.na(preds$actual_margin), ]
+    bt_results_dt <- data.table::data.table(team = strength_dt$team,
+                                            bt_results = NA_real_, bt_results_se = NA_real_)
+    if (nrow(season_played) >= 2) {
+      bt_teams <- sort(unique(c(season_played$home_team, season_played$away_team)))
+      if (length(bt_teams) >= 2) {
+        ref_team <- bt_teams[1]
+        other_teams <- bt_teams[-1]
+        # make.names() sidesteps as.data.frame()'s check.names mangling teams
+        # with spaces (e.g. "West Coast") into differently-shaped column names
+        safe_names <- make.names(other_teams, unique = TRUE)
+        X <- matrix(0, nrow = nrow(season_played), ncol = length(other_teams),
+                    dimnames = list(NULL, safe_names))
+        for (i in seq_len(nrow(season_played))) {
+          hi <- match(season_played$home_team[i], other_teams)
+          ai <- match(season_played$away_team[i], other_teams)
+          if (!is.na(hi)) X[i, hi] <- X[i, hi] + 1
+          if (!is.na(ai)) X[i, ai] <- X[i, ai] - 1
+        }
+        y <- with(season_played, ifelse(actual_margin > 0, 1,
+                                        ifelse(actual_margin < 0, 0, 0.5)))
+        glm_df <- as.data.frame(X)
+        glm_df$home_adv <- 1
+        glm_df$y <- y
+        bt_fit <- stats::glm(y ~ . - 1, data = glm_df, family = stats::binomial())
+        co <- summary(bt_fit)$coefficients
+        est <- co[safe_names, "Estimate"];   names(est) <- other_teams
+        se  <- co[safe_names, "Std. Error"]; names(se)  <- other_teams
+        full_est <- c(setNames(0, ref_team), est)
+        full_se  <- c(setNames(NA_real_, ref_team), se)
+        full_est <- full_est - mean(full_est)
+        bt_results_dt <- data.table::data.table(team = names(full_est),
+                                                bt_results = round(as.numeric(full_est), 4),
+                                                bt_results_se = round(as.numeric(full_se), 4))
+      }
+    }
+    strength_dt <- merge(strength_dt, bt_results_dt, by = "team", all.x = TRUE)
+
+    # --- bt_model: Bradley-Terry fitted on the MODEL'S predicted probabilities
+    # (this season's full predictions.parquet fixture set — played AND future
+    # rounds, using home_win_prob), NOT actual results — that's what
+    # bt_results is for. DISPLAY/REFERENCE ONLY — never a sim input. Mirrors
+    # panna::fit_bt_ratings() (pannaverse/panna/R/team_rating.R): cross-entropy
+    # optimisation via L-BFGS-B, mean-centered ratings, a home-advantage
+    # parameter. Drops panna's Davidson draw parameter (nu) — AFL
+    # predictions.parquet carries a single home_win_prob, not a W/D/L split,
+    # and draws are ~1% of games, so a simplified 2-outcome (no-draw) variant
+    # is used instead of fitting/estimating nu from a proxy. When the future
+    # 612-row directed matchup table (18x17 pairs x2 venues) exists, refit this
+    # on all ordered pairs instead of the fixture subset.
+    season_fixtures <- preds[preds$season == current_season & !is.na(preds$home_win_prob), ]
+    bt_model_dt <- data.table::data.table(team = strength_dt$team, bt_model = NA_real_)
+    if (nrow(season_fixtures) >= 2) {
+      bm_teams <- sort(unique(c(season_fixtures$home_team, season_fixtures$away_team)))
+      if (length(bm_teams) >= 2) {
+        n_bm <- length(bm_teams)
+        idx_home <- match(season_fixtures$home_team, bm_teams)
+        idx_away <- match(season_fixtures$away_team, bm_teams)
+        p_obs <- pmin(pmax(season_fixtures$home_win_prob, 1e-6), 1 - 1e-6)
+        loss_fn <- function(par) {
+          r <- par[1:n_bm]; r <- r - mean(r)
+          hadv <- par[n_bm + 1L]
+          logit_p <- r[idx_home] - r[idx_away] + hadv
+          p_model <- 1 / (1 + exp(-logit_p))
+          p_model <- pmin(pmax(p_model, 1e-9), 1 - 1e-9)
+          -sum(p_obs * log(p_model) + (1 - p_obs) * log(1 - p_model))
+        }
+        init <- c(rep(0, n_bm), 0.25)
+        bm_fit <- stats::optim(init, loss_fn, method = "L-BFGS-B",
+                               control = list(maxit = 200, factr = 1e7))
+        r_bm <- bm_fit$par[1:n_bm]; r_bm <- r_bm - mean(r_bm)
+        bt_model_dt <- data.table::data.table(team = bm_teams, bt_model = round(r_bm, 4))
+      }
+    }
+    strength_dt <- merge(strength_dt, bt_model_dt, by = "team", all.x = TRUE)
+
+    strength_dt[, season := current_season]
+    strength_dt[, round := latest_round]
+    strength_dt[, updated := as.character(Sys.time())]
+    data.table::setcolorder(strength_dt, c("team", "torp", "residual_mean", "residual_se",
+                                           "bt_results", "bt_results_se", "bt_model",
+                                           "season", "round", "updated"))
+
+    write_parquet(as.data.frame(strength_dt), "blog/team-strength.parquet")
+    cat("team-strength:", nrow(strength_dt), "teams\n")
+    print(strength_dt[order(-bt_results), .(team, torp, residual_mean, bt_results, bt_model)])
+  }, error = function(e) {
+    message("::warning::Team-strength export failed, skipping team-strength.parquet: ",
+            conditionMessage(e))
+  })
 }, error = function(e) {
   message("::warning::Simulation failed, skipping simulations.parquet: ",
           conditionMessage(e))


### PR DESCRIPTION
`build-blog-data.yml`'s setup-r-dependencies uses a bare package list with no working-directory, so it never resolves torp's DESCRIPTION Imports — add `any::rvest` explicitly. The other two workflows resolve torp's DESCRIPTION and are covered by the torp-side Suggests→Imports move.

**Recommend merging together with the torp #105 PR** — both are needed before the nightly pipeline produces a weekly-sourced `afl/injuries.parquet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)