### PR TITLE
team-strength points columns + Final Ten column threading

### DIFF
--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -901,7 +901,10 @@ if (torp_loaded) {
     runner_up_pct   = sum(finals_finish == 4) / n_sims_val,
     lose_prelim_pct = sum(finals_finish == 3) / n_sims_val,
     lose_semi_pct   = sum(finals_finish == 2) / n_sims_val,
-    lose_elim_pct   = sum(finals_finish == 1) / n_sims_val
+    lose_elim_pct   = sum(finals_finish == 1) / n_sims_val,
+    # finals_finish == 0 = lost a Wildcard Final (Final Ten system, torp#106).
+    # Zero for every team until the torp finals rewrite ships — harmless before.
+    lose_wildcard_pct = sum(finals_finish == 0) / n_sims_val
   ), by = team]
 
   # Position distribution from ladder results

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -937,9 +937,13 @@ if (torp_loaded) {
   })
 
   # Merge summary + current standings + finals stages + position distribution
+  # top_10_pct = the finals cutoff under the 2026 Final Ten system; top_6_pct =
+  # skips the Wildcard Round. Both computed by torp since April 2026 but never
+  # threaded through here (blog fallback showed top-8 as "finals" — torp#106).
+  # lose_wildcard_pct joins finals_stage once torp#106's finals rewrite ships.
   sim_output <- merge(
     summary_dt[, .(team, avg_wins, avg_losses, avg_percentage, avg_rank,
-                   top_1_pct, top_4_pct, top_8_pct, last_pct)],
+                   top_1_pct, top_4_pct, top_6_pct, top_8_pct, top_10_pct, last_pct)],
     current, by = "team", all.x = TRUE
   )
   sim_output <- merge(sim_output, finals_stage, by = "team", all.x = TRUE)


### PR DESCRIPTION
Follow-ups riding together: `pts_results`/`pts_model` Massey margin-fit columns (+ `pts_home_adv`) added to team-strength.parquet alongside the BT log-odds pair; `top_10_pct`/`top_6_pct` threaded into simulations.parquet's column selection (torp computed them since April, never shipped); `lose_wildcard_pct` from `finals_finish == 0` (zero until torp#106 merges, populates automatically after).

**Recommend merging together with the torp Final Ten PR**, then one `build-blog-data` dispatch ships the complete set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)