### PR TITLE
Set VERSEBUS_STRICT=1 at workflow level

### DIFF
--- a/.github/workflows/daily-data-release.yml
+++ b/.github/workflows/daily-data-release.yml
@@ -52,6 +52,7 @@ env:
   GITHUB_PAT: ${{ secrets.WORKFLOW_PAT }}
   R_KEEP_PKG_SOURCE: yes
   piggyback_cache_duration: 1
+  VERSEBUS_STRICT: "1"
 
 jobs:
   release-data:

--- a/.github/workflows/lineup-predictions.yml
+++ b/.github/workflows/lineup-predictions.yml
@@ -15,6 +15,7 @@ env:
   GITHUB_PAT: ${{ secrets.WORKFLOW_PAT }}
   R_KEEP_PKG_SOURCE: yes
   piggyback_cache_duration: 1
+  VERSEBUS_STRICT: "1"
 
 concurrency:
   group: daily-release


### PR DESCRIPTION
Versebus phase-3 rollout tail (torpverse FABLE-C6-SHIP-PLAN step 6, deferred until the C6 retrain ran green — confirmed 4 green runs through 2026-07-20).

Both daily-data-release and lineup-predictions run torp's `run_daily_release()`, whose entry script already sets strict mode since 2026-07-11; the workflow-level `env:` makes every step strict and the CI posture explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoedPoJcKaGRUUg8Q1YpJw