### PR TITLE
Tag predictions.parquet rows with source (locked vs retrodiction)

### DIFF
--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -110,10 +110,14 @@ preds_list <- lapply(pred_files, function(f) {
   }
 })
 preds <- bind_rows(preds_list) |>
-  mutate(round = as.integer(round)) |>
+  mutate(round = as.integer(round), source = "locked") |>
   arrange(season, round, desc(abs(pred_margin)))
 
-# Backfill with retrodictions for rounds that have no locked predictions
+# Backfill with retrodictions for rounds that have no locked predictions.
+# Retrodiction rows use current/final ratings applied uniformly to every match
+# (including past ones), so they're leaky vs. the walk-forward-safe locked
+# predictions above — tagged via `source` so consumers (e.g. the blog's as-at
+# time-travel scrubber) can filter them out (torpdata#78).
 retro_files <- list.files("source", pattern = "^retrodictions_", full.names = TRUE)
 if (length(retro_files) > 0) {
   retro_list <- lapply(retro_files, function(f) {
@@ -143,7 +147,8 @@ if (length(retro_files) > 0) {
   retro <- bind_rows(retro_list)
   # Only add retrodiction rows for season+round+home+away combos missing from predictions
   retro_new <- retro |>
-    anti_join(preds, by = c("season", "round", "home_team", "away_team"))
+    anti_join(preds, by = c("season", "round", "home_team", "away_team")) |>
+    mutate(source = "retrodiction")
   if (nrow(retro_new) > 0) {
     preds <- bind_rows(preds, retro_new) |> arrange(season, round, desc(abs(pred_margin)))
     cat("Backfilled", nrow(retro_new), "matches from retrodictions\n")


### PR DESCRIPTION
## Summary
- Adds a `source` column (`locked` / `retrodiction`) to the merged predictions table in `build_blog_data.R`, so `predictions.parquet` no longer conflates walk-forward-safe locked predictions with leaky retrodiction backfill rows.
- Consumers (e.g. the blog's as-at time-travel scrubber) can now filter/flag retrodiction rows instead of silently treating them as genuine pre-match predictions.

Fixes #78

## Test plan
- [x] `Rscript`-based syntax parse check on `scripts/build_blog_data.R`
- [ ] Manual run of `build_blog_data.R` (or `build-blog-data.yml` dispatch) to confirm `blog/predictions.parquet` carries the new `source` column end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ciGbk49bKQ1WK91gZ4veH