### PR TITLE
Add dated-snapshot export for predictions/injuries parquets

### DIFF
--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -256,6 +256,24 @@ jobs:
             fi
           done
 
+      - name: Snapshot dated predictions + injuries (torpdata#77)
+        run: |
+          # Insurance for future-season as-at replay fidelity: predictions.parquet
+          # and injuries.parquet are otherwise only ever published as "latest",
+          # overwritten every run — a past as-at replay can't reconstruct what the
+          # model actually said on a given historical date without a dated copy.
+          # Flat filenames land in the same afl/ R2 prefix as everything else via
+          # the existing blog/*.parquet upload loop below (no loop changes needed).
+          # Retention/pruning not implemented yet — R2 storage is cheap and this
+          # is a low-volume daily snapshot; revisit if it ever needs bounding.
+          DATE=$(date -u +%Y-%m-%d)
+          if [ -f blog/predictions.parquet ]; then
+            cp blog/predictions.parquet "blog/predictions-snapshot-${DATE}.parquet"
+          fi
+          if [ -f blog/injuries.parquet ]; then
+            cp blog/injuries.parquet "blog/injuries-snapshot-${DATE}.parquet"
+          fi
+
       - uses: actions/setup-node@v6
         with:
           node-version: '20'


### PR DESCRIPTION
## Summary
- Adds a new `Snapshot dated predictions + injuries` step to `build-blog-data.yml`, between "Validate outputs" and "Upload to R2".
- Copies `blog/predictions.parquet`/`blog/injuries.parquet` to dated filenames (`predictions-snapshot-YYYY-MM-DD.parquet` / `injuries-snapshot-YYYY-MM-DD.parquet`) before the existing R2 upload loop runs, so they ride the same `blog/*.parquet` glob → `afl/` R2 prefix without any loop changes.
- Insurance for next season's as-at replay fidelity (inthegame-blog's Tier-0 fidelity caveat) — currently only "latest" is ever published, so a future as-at replay can't reconstruct what the model actually said on a given historical date.
- No retention/pruning implemented (left as a documented, non-blocking gap per the issue's own "your call on retention" framing) — low-volume daily snapshot, R2 storage is cheap.

Fixes #77

## Test plan
- [x] `yaml.safe_load` parse check on the full workflow file
- [x] Code review (Sonnet, medium effort) — no issues found
- [ ] `build-blog-data.yml` dispatched on `dev` (commit eb16d12) to confirm the snapshot files actually appear in `blog/` and upload to R2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ciGbk49bKQ1WK91gZ4veH